### PR TITLE
(Fix James-Yu#1528) Launch pdftex with child_process.exec

### DIFF
--- a/src/components/tikzpictureview.ts
+++ b/src/components/tikzpictureview.ts
@@ -321,20 +321,7 @@ export class TikzPictureView {
     private precompilePreamble(file: string, preamble: string) {
         return new Promise((resolve, reject) => {
             fs.writeFileSync(file, `\\documentclass{standalone}\n\n${preamble}\n\n\\begin{document}\\end{document}`)
-            const process = child_process.spawn(
-                'pdftex',
-                [
-                    '-ini',
-                    '-interaction=nonstopmode',
-                    '-shell-escape',
-                    '-file-line-error',
-                    '-jobname="preamble"',
-                    '"&pdflatex"',
-                    'mylatexformat.ltx',
-                    `"${file}"`
-                ],
-                { cwd: path.dirname(file) }
-            )
+            const process = child_process.exec( `pdftex -ini -interaction=nonstopmode -shell-escape -file-line-error -jobname="preamble" "&pdflatex" mylatexformat.ltx ${path.basename(file)}`, { cwd: path.dirname(file) } )
             process.on('exit', _code => {
                 resolve()
             })


### PR DESCRIPTION
MiKTeX's pdftex has issues launching with child_process.spawn for whatever reason.

Also, MiKTeX's pdftex complained about being sent an absolute path, so I changed it to a relative one.

This works for me on Windows/MiKTeX and Linux/TeXLive.

James-Yu#1528